### PR TITLE
Make work on nixpkgs-unstable, as programs.emacs.package

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -211,13 +211,12 @@ let
             (load "${doom-emacs}/early-init.el"))
       (load "${doom-emacs}/init.el")
     '';
-
   in (emacsPackages.emacsWithPackages (epkgs: [
     load-config-from-site
   ]));
 in
 pkgs.runCommand "doom-emacs" {
-  inherit doom-emacs emacs;
+  inherit emacs;
   buildInputs = [ emacs ];
   nativeBuildInputs = [ makeWrapper ];
 } ''
@@ -225,4 +224,10 @@ pkgs.runCommand "doom-emacs" {
     for prog in $emacs/bin/*; do
       makeWrapper $prog $out/bin/$(basename $prog) --set DOOMDIR ${doomDir}
     done
+    # emacsWithPackages assumes share/emacs/site-lisp/subdirs.el
+    # exists, but doesn't pass it along.  When home-manager calls
+    # emacsWithPackages again on this derivation, it fails due to
+    # a dangling link to subdirs.el.
+    # https://github.com/NixOS/nixpkgs/issues/66706
+    ln -s ${emacs.emacs}/share $out
   ''


### PR DESCRIPTION
Thanks for this project!  I don't know whether any of this is useful to you, but I needed to make some tweaks and thought I'd offer it back.

In NixOS/nixpkgs#69045, `emacsWithPackages` was rewritten as a `runCommand` and lost its `installPhase`.  I rearranged it the code to use another `runCommand` instead of overriding the phase that no longer exists.  I expect this will break on 19.09, but it was necessary on unstable.

Secondly, I wanted to declare doom as the emacs package in home-manager, so I could continue to use its systemd service.  The extra call to `emacsWithPackages` that this introduces causes a failure similar to https://github.com/NixOS/nixpkgs/issues/66706, so I make sure our doom-emacs includes the lisp.  I'm not sure if this was wise, but it's working for me.

The only weirdness I see so far is that if I launch `emacs` directly, I get the default emacs startup screen rather than the doom dashboard.  If I call `emacsclient -c`, I get the regular doom dash.  I'm not sure if that's a result of my change or pre-existing.