### PR TITLE
Use recursive flag on `cp` for private directory

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -203,7 +203,7 @@ let
     passAsFile = [ "extraConfig" ];
   } ''
       mkdir -p $out
-      cp ${doomPrivateDir}/* $out
+      cp -r ${doomPrivateDir}/* $out
       chmod u+w $out/config.el
       cat $extraConfigPath >> $out/config.el
   '';


### PR DESCRIPTION
If the private directory has multiple folders in it, building the derivation will omit them.