### PR TITLE
add usage and troubleshooting in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,11 @@ in {
 This expression leverages
 [nix-straight.el](https://github.com/vlaci/nix-straight.el) under the hood for
 installing depdendencies. The restrictions of that package apply here too.
+
+## Usage
+
+instead of running emacs.d/bin/doom, once you have update your config files (packages.el, init.el, config.el), rebuild doom-emacs with nix. If you are using home-manager, simply run `home-manager switch`
+
+## Troubleshooting
+
+On macOS on a fresh install, you might run into the error `Too many files open`. running `ulimit -S -n 2048` will only work for the duration of your shell and will fix the error


### PR DESCRIPTION
add a usage section to clarify how to update and sync doom

fixes https://github.com/vlaci/nix-doom-emacs/issues/25

I've also added a troubleshooting section for something I encountered on darwin.

Let me know if there is anything.