### PR TITLE
[WIP] Flake support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,41 @@ in {
 }
 ```
 
+Using `flake.nix`:
+
+``` nix
+{
+  inputs = {
+    home-manager.url = "github:rycee/home-manager";
+    nix-doom-emacs.url = "github:vlaci/nix-doom-emacs/flake";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    home-manager,
+    nix-doom-emacs,
+    ...
+  }: {
+    nixosConfigurations.exampleHost = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        home-manager.nixosModules.home-manager
+        {
+          home-manager.users.exampleUser = { pkgs, ... }: {
+            imports = [ nix-doom-emacs.hmModule ];
+            home.doom-emacs = {
+              enable = true;
+              doomPrivateDir = ./doom.d;
+            };
+          };
+        }
+      ];
+    };
+  };
+}
+```
+
 ## Under the hood
 
 This expression leverages

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ compatible with the `doom-emacs` requirements.
 
 Using [home-manager](https://github.com/rycee/home-manager):
 
- ``` nix
+``` nix
 { pkgs, ... }:
 
 let

--- a/flake.nix
+++ b/flake.nix
@@ -4,8 +4,6 @@
     inputs = {
       home-manager.url = "github:rycee/home-manager";
       nix-doom-emacs.url = "github:vlaci/nix-doom-emacs/flake";
-      doomPrivateDir.url = "/path/to/doom.d";
-      doomPrivateDir.flake = false;
     };
 
     outputs = {
@@ -13,7 +11,6 @@
       nixpkgs,
       home-manager,
       nix-doom-emacs,
-      doomPrivateDir,
       ...
     }: {
       nixosConfigurations.exampleHost = nixpkgs.lib.nixosSystem {
@@ -25,7 +22,7 @@
               imports = [ nix-doom-emacs.hmModule ];
               home.doom-emacs = {
                 enable = true;
-                inherit doomPrivateDir;
+                doomPrivateDir = ./path/to/doom.d;
               };
             };
           }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,79 @@
+/* Usage example in flake.nix:
+
+  {
+    inputs = {
+      home-manager.url = "github:rycee/home-manager";
+      nix-doom-emacs.url = "github:vlaci/nix-doom-emacs/flake";
+      doomPrivateDir.url = "/path/to/doom.d";
+      doomPrivateDir.flake = false;
+    };
+
+    outputs = {
+      self,
+      nixpkgs,
+      home-manager,
+      nix-doom-emacs,
+      doomPrivateDir,
+      ...
+    }: {
+      nixosConfigurations.exampleHost = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [
+          home-manager.nixosModules.home-manager
+          {
+            home-manager.users.exampleUser = { pkgs, ... }: {
+              imports = [ nix-doom-emacs.hmModule ];
+              home.doom-emacs = {
+                enable = true;
+                inherit doomPrivateDir;
+              };
+            };
+          }
+        ];
+      };
+    };
+  }
+*/
+
+{
+  description = "nix-doom-emacs home-manager module";
+
+  inputs = {
+    doom-emacs.url = "github:hlissner/doom-emacs/develop";
+    doom-emacs.flake = false;
+    doom-snippets.url = "github:hlissner/doom-snippets";
+    doom-snippets.flake = false;
+    emacs-overlay.url = "github:nix-community/emacs-overlay";
+    emacs-overlay.flake = false;
+    emacs-so-long.url = "github:hlissner/emacs-so-long";
+    emacs-so-long.flake = false;
+    evil-markdown.url = "github:Somelauw/evil-markdown";
+    evil-markdown.flake = false;
+    evil-org-mode.url = "github:hlissner/evil-org-mode";
+    evil-org-mode.flake = false;
+    evil-quick-diff.url = "github:rgrinberg/evil-quick-diff";
+    evil-quick-diff.flake = false;
+    explain-pause-mode.url = "github:lastquestion/explain-pause-mode";
+    explain-pause-mode.flake = false;
+    "nix-straight.el".url = "github:vlaci/nix-straight.el/v2.1.0";
+    "nix-straight.el".flake = false;
+    nose.url= "github:emacsattic/nose";
+    nose.flake = false;
+    ob-racket.url = "github:xchrishawk/ob-racket";
+    ob-racket.flake = false;
+    org-mode.url = "github:emacs-straight/org-mode";
+    org-mode.flake = false;
+    org-yt.url = "github:TobiasZawada/org-yt";
+    org-yt.flake = false;
+    php-extras.url = "github:arnested/php-extras";
+    php-extras.flake = false;
+    "reveal.js".url = "github:hakimel/reveal.js";
+    "reveal.js".flake = false;
+    "rotate-text.el".url = "github:debug-ito/rotate-text.el";
+    "rotate-text.el".flake = false;
+  };
+
+  outputs = inputs: {
+      hmModule = import ./modules/home-manager.nix inputs;
+  };
+}

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -40,6 +40,17 @@ in
       default = [ ];
       example = literalExample "[ pkgs.mu ]";
     };
+    emacsPackage = mkOption {
+      description = ''
+        Emacs package to use.
+
+        Override this if you want to use a custom emacs derivation to base
+        `doom-emacs` on.
+      '';
+      type = with types; package;
+      default = pkgs.emacs;
+      example = literalExample "pkgs.emacs";
+    };
     package = mkOption {
       internal = true;
     };
@@ -49,6 +60,7 @@ in
     let
       emacs = pkgs.callPackage self {
         extraPackages = (epkgs: cfg.extraPackages);
+        emacsPackages = pkgs.emacsPackagesFor cfg.emacsPackage;
         inherit (cfg) doomPrivateDir extraConfig;
         dependencyOverrides = inputs;
       };

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -14,6 +14,7 @@ in
         The specified directory should  contain yoour `init.el`, `config.el` and
         `packages.el` files.
       '';
+      apply = path: builtins.path { inherit path; };
     };
     extraConfig = mkOption {
       description = ''

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -1,0 +1,67 @@
+{ self, ... }@inputs:
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.programs.doom-emacs;
+  inherit (lib) literalExample mkEnableOption mkIf mkOption types;
+in
+{
+  options.programs.doom-emacs = {
+    enable = mkEnableOption "Doom Emacs configuration";
+    doomPrivateDir = mkOption {
+      description = ''
+        Path to your `.doom.d` directory.
+
+        The specified directory should  contain yoour `init.el`, `config.el` and
+        `packages.el` files.
+      '';
+    };
+    extraConfig = mkOption {
+      description = ''
+        Extra configuration options to pass to doom-emacs.
+
+        Elisp code set here will be appended at the end of `config.el`. This
+        option is useful for refering `nixpkgs` derivation in Emacs without the
+        need to install them globally.
+      '';
+      type = with types; lines;
+      default = "";
+      example = literalExample ''
+        (setq mu4e-mu-binary = "''${pkgs.mu}/bin/mu")
+      '';
+    };
+    extraPackages = mkOption {
+      description = ''
+        Extra packages to install.
+
+        List addition non-emacs packages here that ship elisp emacs bindings.
+      '';
+      type = with types; listOf package;
+      default = [ ];
+      example = literalExample "[ pkgs.mu ]";
+    };
+    package = mkOption {
+      internal = true;
+    };
+  };
+
+  config = mkIf cfg.enable (
+    let
+      emacs = pkgs.callPackage self {
+        extraPackages = (epkgs: cfg.extraPackages);
+        inherit (cfg) doomPrivateDir extraConfig;
+        dependencyOverrides = inputs;
+      };
+    in
+    {
+      home.file.".emacs.d/init.el".text = ''
+        (load "default.el")
+      '';
+      home.packages = with pkgs; [
+        emacs-all-the-icons-fonts
+      ];
+      programs.emacs.package = emacs;
+      programs.emacs.enable = true;
+      programs.doom-emacs.package = emacs;
+    }
+  );
+}


### PR DESCRIPTION
Dependencies are not locked, so each `nix flake update` call pulls in the latest doom sources.
 
Adding a `flake.nix` file makes it easy to extend home-manager with a doom specific module:

```nix
{
  inputs = {
    home-manager.url = "github:rycee/home-manager";
    nix-doom-emacs.url = "github:vlaci/nix-doom-emacs/flake";
  };

  outputs = {
    self,
    nixpkgs,
    home-manager,
    nix-doom-emacs,
    ...
  }: {
    nixosConfigurations.exampleHost = nixpkgs.lib.nixosSystem {
      system = "x86_64-linux";
      modules = [
        home-manager.nixosModules.home-manager
        {
          home-manager.users.exampleUser = { pkgs, ... }: {
            imports = [ nix-doom-emacs.hmModule ];
            home.doom-emacs = {
              enable = true;
              doomPrivateDir = ./doom.d;
            };
          };
        }
      ];
    };
  };
}
```

Note, that flakes are not strictly needed to achieve that as the packaging could be extended to deliver a module alongside of the main derivation in an attrset. Module support is an added bonus to a more sophisticated dependency tracking.