### PR TITLE
advice.el: manually call (straight--make-build-cache-available)

### DIFF
--- a/advice.el
+++ b/advice.el
@@ -41,4 +41,6 @@
 
 ;; just use straight provided by nix
 (advice-add 'doom-initialize-core-packages
-            :override (lambda (&rest r) (require 'straight)))
+            :override (lambda (&rest r)
+                        (require 'straight)
+                        (straight--make-build-cache-available)))


### PR DESCRIPTION
Excerpt from build log:

> x There was an unexpected error
>   Message: Wrong type argument
>   Data: (wrong-type-argument . hash-table-p)
>   Backtrace:
>     (gethash auto-minor-mode nil)
>     (straight--get-dependencies auto-minor-mode)
>     (cons name (straight--get-dependencies name))
>     (let ((--dolist-tail-- (cons name (straight--get-dependencies name)))) (wh
>     (if disable (let* ((var name)) (if (memql var doom-disabled-packages) (wit
>     (if ignore nil (if disable (let* ((var name)) (if (memql var doom-disabled
>     (let* ((--cl-rest-- package) (name (if --cl-rest-- (car-safe (prog1 --cl-r
>     (let ((package (car --dolist-tail--))) (let* ((--cl-rest-- package) (name
>     (while --dolist-tail-- (let ((package (car --dolist-tail--))) (let* ((--cl
>     (let ((--dolist-tail-- doom-packages)) (while --dolist-tail-- (let ((packa
> ! Extended backtrace logged to /nix/store/56740akcqrwqji0ll3sn26z8cpq8c8sk-straight-emacs-env/doom.error.log
> builder for '/nix/store/z2pf5dl4n2kiwfmqb233zj0srkwyn5vp-straight-emacs-env.drv' failed with exit code 255
> cannot build derivation '/nix/store/ykmx8a4p0cn23ngpma5db35fzz1y50w4-emacs-with-packages-27.1.drv': 1 dependencies couldn't be built
> error: build of '/nix/store/ykmx8a4p0cn23ngpma5db35fzz1y50w4-emacs-with-packages-27.1.drv' failed

Issue has been introduced here:

> commit 2c646df0279091eb1ad32196ac93ff172c067997
>
>     Initialize more straight state in doom-initialize-packages
>
>     May address #3172 and some issues with certain files failing to
>     byte-compile because certain dependencies were missing at compile-time

Fixes: #109