### PR TITLE
Allow doomPrivateDir to be a /nix/store path

### DIFF
--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -20,7 +20,7 @@ in
         The specified directory should  contain yoour `init.el`, `config.el` and
         `packages.el` files.
       '';
-      apply = path: builtins.path { inherit path; };
+      apply = path: if lib.isStorePath path then path else builtins.path { inherit path; };
     };
     extraConfig = mkOption {
       description = ''


### PR DESCRIPTION
I've been playing around with a custom home-manager module that extends this one that generates `init.el` programmatically. However, I can't use the `doom.d` folder it generates, because `doomPrivateDir` calls `builtins.path` which fails if given a `/nix/store` path.

This PR fixes `doomPrivateDir` to only call `builtins.path` if the given `path` is not already a `/nix/store` path.