### PR TITLE
Revert "flake.lock: Updating 'emacs-overlay (nix-community/emacs-overlay)' - d9530a70 -> 155972bb"

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     "emacs-overlay": {
       "flake": false,
       "locked": {
-        "lastModified": 1617908665,
-        "narHash": "sha256-h5bQvZAhj3UkAas+aw+i/aPcqb/mTCT28zCj+McrQ4k=",
+        "lastModified": 1616214656,
+        "narHash": "sha256-ceFOGcsbGlP/qtxMBlRGFH5fsbN+uGQYeHUrpgcRS4U=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "155972bbf82bf247dd2c8c6e3000b48feacbdc39",
+        "rev": "d9530a7048f4b1c0f65825202a0ce1d111a1d39a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
There are too many broken packages after using this revision (at least `emacs-org-re-reveal` and `emacs-spell-fu`)

Reverts vlaci/nix-doom-emacs#186