### PR TITLE
Fix nix-integration.patch.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "doom-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1619055904,
-        "narHash": "sha256-/D1u/smt0y+VUb5t4LHHRbvfM4WKDCIZPHN5m3eOPbk=",
+        "lastModified": 1620845520,
+        "narHash": "sha256-XTyH1e+mBVmKM/AWMTuByzQCwj3nTCboutbBeCDjRSY=",
         "owner": "hlissner",
         "repo": "doom-emacs",
-        "rev": "f621ff80471e8d08a72e5ece00641c70b121873a",
+        "rev": "6d2c6b44fa915ed5db8ebcae91e9355a9ef7b663",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     "doom-snippets": {
       "flake": false,
       "locked": {
-        "lastModified": 1613230104,
-        "narHash": "sha256-PUykdv279XJSG8m7ifP/rr4uFs1Mpx6ZyZ3XqvbDW9U=",
+        "lastModified": 1620675968,
+        "narHash": "sha256-Hhq9ZEZnTJoJ4YpGbhNo07nwXmhKT6UCo9wpePurogM=",
         "owner": "hlissner",
         "repo": "doom-snippets",
-        "rev": "afe549bd63403cec5187371ec1986e68a9e5ee3c",
+        "rev": "f7747da6343aadfbe8a3f9e6b35018ac19db4438",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     "emacs-overlay": {
       "flake": false,
       "locked": {
-        "lastModified": 1616214656,
-        "narHash": "sha256-ceFOGcsbGlP/qtxMBlRGFH5fsbN+uGQYeHUrpgcRS4U=",
+        "lastModified": 1620846214,
+        "narHash": "sha256-UUXiIh+WvxKlAoH2pwD1N53AIKMRh5xG+fu6Sze+55w=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d9530a7048f4b1c0f65825202a0ce1d111a1d39a",
+        "rev": "056fa116d903c28e9a6989be1b40132fdb6bf0fe",
         "type": "github"
       },
       "original": {
@@ -131,11 +131,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1618868421,
-        "narHash": "sha256-vyoJhLV6cJ8/tWz+l9HZLIkb9Rd9esE7p+0RL6zDR6Y=",
+        "lastModified": 1620759905,
+        "narHash": "sha256-WiyWawrgmyN0EdmiHyG2V+fqReiVi8bM9cRdMaKQOFg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "eed214942bcfb3a8cc09eb3b28ca7d7221e44a94",
+        "rev": "b543720b25df6ffdfcf9227afafc5b8c1fabfae8",
         "type": "github"
       },
       "original": {
@@ -163,11 +163,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1619105186,
-        "narHash": "sha256-n/+A1JUMhJjs2eQAcWFrC9FRNENWaiLr+q9NKSd1EQU=",
+        "lastModified": 1620838695,
+        "narHash": "sha256-Eb3xr6aWt3lF8BgmZCgVJXy/ArmudeJXONGSqaSLfP0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cd0ffd3f5fad719586a9b2d06b1faa603da6ba8d",
+        "rev": "acd49fab8ece11a89ef8ee49903e1cd7bb50f4b7",
         "type": "github"
       },
       "original": {
@@ -211,11 +211,11 @@
     "org-mode": {
       "flake": false,
       "locked": {
-        "lastModified": 1618887358,
-        "narHash": "sha256-dU9+/QjQ3I4qeyENtgOA7e1H6whsl1W3nJzlBVNL8S8=",
+        "lastModified": 1620793993,
+        "narHash": "sha256-fS8lp/0wqGimBepRocexCJggGAb+GW+33lPghMG8SiE=",
         "owner": "emacs-straight",
         "repo": "org-mode",
-        "rev": "e641d3736036732e7642807146a97b0876cb8b83",
+        "rev": "27621a5b03beb3d164b815eb7268d160de1c6d2e",
         "type": "github"
       },
       "original": {

--- a/nix-integration.patch
+++ b/nix-integration.patch
@@ -1,8 +1,8 @@
 diff --git a/core/core.el b/core/core.el
-index 961f82733..f2dac458f 100644
+index a5f7664db..894c1d641 100644
 --- a/core/core.el
 +++ b/core/core.el
-@@ -69,7 +69,7 @@ envvar will enable this at startup.")
+@@ -75,7 +75,7 @@ envvar will enable this at startup.")
    (let ((localdir (getenv-internal "DOOMLOCALDIR")))
      (if localdir
          (expand-file-name (file-name-as-directory localdir))
@@ -11,7 +11,7 @@ index 961f82733..f2dac458f 100644
    "Root directory for local storage.
  
  Use this as a storage location for this system's installation of Doom Emacs.
-@@ -77,13 +77,13 @@ Use this as a storage location for this system's installation of Doom Emacs.
+@@ -83,13 +83,13 @@ Use this as a storage location for this system's installation of Doom Emacs.
  These files should not be shared across systems. By default, it is used by
  `doom-etc-dir' and `doom-cache-dir'. Must end with a slash.")
  
@@ -27,13 +27,13 @@ index 961f82733..f2dac458f 100644
    "Directory for volatile local storage.
  
  Use this for files that change often, like cache files. Must end with a slash.")
-@@ -152,7 +152,8 @@ users).")
+@@ -175,7 +175,8 @@ users).")
  ;; Don't store eln files in ~/.emacs.d/eln-cache (they are likely to be purged
  ;; when upgrading Doom).
- (when (boundp 'comp-eln-load-path)
--  (add-to-list 'comp-eln-load-path (concat doom-cache-dir "eln/")))
-+  (add-to-list 'comp-eln-load-path (concat doom-cache-dir "eln/"))
-+  (add-to-list 'comp-eln-load-path (concat doom-local-dir "cache/eln/")))
+ (when (boundp 'native-comp-eln-load-path)
+-  (add-to-list 'native-comp-eln-load-path (concat doom-cache-dir "eln/")))
++  (add-to-list 'native-comp-eln-load-path (concat doom-cache-dir "eln/"))
++  (add-to-list 'native-comp-eln-load-path (concat doom-local-dir "cache/eln/")))
  
  (with-eval-after-load 'comp
    ;; HACK Disable native-compilation for some troublesome packages


### PR DESCRIPTION
`comp-eln-load-path` was renamed to `native-comp-eln-load-path` in doom-emacs:
https://github.com/hlissner/doom-emacs/commit/856f8b6aeb3d9d699963f26765ca12fc5a2a511e