### PR TITLE
In emacs 28+ the 'comp-never-optimize-functions was renamed to 'native-comp-never-optimize-functions.

### DIFF
--- a/advice.el
+++ b/advice.el
@@ -11,7 +11,12 @@
 (with-eval-after-load "comp"
   ;; The advice for 'kill-emacs would result in eln files being written before
   ;; doom would set up proper load paths
-  (add-to-list 'comp-never-optimize-functions 'kill-emacs))
+  (when (boundp 'comp-never-optimize-functions)
+    ;; TODO Remove this when emacs 28 become stable.
+    (add-to-list 'comp-never-optimize-functions 'kill-emacs))
+  (when (boundp 'native-comp-never-optimize-functions)
+    (add-to-list 'native-comp-never-optimize-functions 'kill-emacs))
+  )
 
 (defun nix-straight-inhibit-kill-emacs (arg)
   (message "[nix-doom-emacs] Inhibiting (kill-emacs)"))


### PR DESCRIPTION
Hello.

The `comp-never-optimize-functions` was renamed to `native-comp-never-optimize-functions` (see [this commit](https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=31ca1c3e81b26357692c4c2428744f7f2f153596)).

This PR addresses this issue keeping BC.