### PR TITLE
advice.el: make it compatible with newer doom revisions

### DIFF
--- a/advice.el
+++ b/advice.el
@@ -24,7 +24,7 @@
                                               (message "[nix-doom-emacs] Skipping generating autoloads...")))
                       (advice-add 'doom--print
                                   :override (lambda (output)
-                                              (message output)))
+                                              (princ (format "%s\n" output) 'external-debugging-output)))
                       (advice-add 'kill-emacs
                                   :override #'nix-straight-inhibit-kill-emacs)
                       (apply orig-fn r)


### PR DESCRIPTION
doom redefines `(message)` to use `(doom--print)` under the hood,
so the previous  advice caused an infinite recursion.

See: https://github.com/hlissner/doom-emacs/commit/4b5cf7d46f01da8688a605b30ea5cd6213ca9508

Fixes: #233