### PR TITLE
Add a patch for restart-emacs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -225,6 +225,7 @@ emacs.overrideAttrs (esuper:
       wrapEmacs() {
           wrapProgram $1 \
                     --set DOOMDIR ${doomDir} \
+                    --set NIX_DOOM_EMACS_BINARY $1 \
                     --set __DEBUG_doom_emacs_DIR ${doom-emacs} \
                     --set __DEBUG_doomLocal_DIR ${doomLocal}
       }

--- a/overrides.nix
+++ b/overrides.nix
@@ -71,6 +71,10 @@ self: super: {
     pname = "php-extras";
   };
 
+  restart-emacs = super.restart-emacs.overrideAttrs (esuper: {
+    patches = [ ./restart-emacs.patch ];
+  });
+
   revealjs = self.straightBuild {
     pname = "revealjs";
 

--- a/restart-emacs.patch
+++ b/restart-emacs.patch
@@ -1,0 +1,22 @@
+--- a/restart-emacs.el	1970-01-01 02:00:01.000000000 +0200
++++ b/restart-emacs.el	2021-06-13 14:37:50.520954543 +0300
+@@ -94,12 +94,13 @@
+   "Get absolute path to binary of currently running Emacs.
+ 
+ On Windows get path to runemacs.exe if possible."
+-  (let ((emacs-binary-path (expand-file-name invocation-name invocation-directory))
+-        (runemacs-binary-path (when (memq system-type '(windows-nt ms-dos))
+-                                (expand-file-name "runemacs.exe" invocation-directory))))
+-    (if (and runemacs-binary-path (file-exists-p runemacs-binary-path))
+-        runemacs-binary-path
+-      emacs-binary-path)))
++  (if (getenv "NIX_DOOM_EMACS_BINARY") (getenv "NIX_DOOM_EMACS_BINARY")
++    (let ((emacs-binary-path (expand-file-name invocation-name invocation-directory))
++          (runemacs-binary-path (when (memq system-type '(windows-nt ms-dos))
++                                  (expand-file-name "runemacs.exe" invocation-directory))))
++      (if (and runemacs-binary-path (file-exists-p runemacs-binary-path))
++          runemacs-binary-path
++        emacs-binary-path))))
+ 
+ (defun restart-emacs--record-tty-file (current &rest ignored)
+   "Save the buffer which is being currently selected in the frame.


### PR DESCRIPTION
Before this change, trying to use `doom/restart-and-restore` would
result in a failed to load `default.el` as the wrong binary would be launched.

This fixes that.