### PR TITLE
set home-manager emacs service's package

### DIFF
--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -98,6 +98,10 @@ in
       ];
       programs.emacs.package = emacs;
       programs.emacs.enable = true;
+
+      # Set the service's package but don't enable. Leave that up to the user
+      services.emacs.package = emacs;
+
       programs.doom-emacs.package = emacs;
     }
   );


### PR DESCRIPTION
Right now if I set
```
services.emacs.enable = true;
```
it still uses vanilla emacs.

Workaround without this patch is to set
```
services.emacs.package = config.programs.emacs.package;
```
then it works as expected.