### PR TITLE
Fix nix-integration.patch

### DIFF
--- a/nix-integration.patch
+++ b/nix-integration.patch
@@ -1,17 +1,17 @@
 diff --git a/core/core.el b/core/core.el
-index a5f7664db..894c1d641 100644
+index aae87b567..112ddd79d 100644
 --- a/core/core.el
 +++ b/core/core.el
-@@ -75,7 +75,7 @@ envvar will enable this at startup.")
-   (let ((localdir (getenv-internal "DOOMLOCALDIR")))
-     (if localdir
-         (expand-file-name (file-name-as-directory localdir))
--      (concat doom-emacs-dir ".local/")))
-+      (concat doom-emacs-dir "@local@/")))
+@@ -67,7 +67,7 @@ envvar will enable this at startup.")
+ (defconst doom-local-dir
+   (if-let (localdir (getenv-internal "DOOMLOCALDIR"))
+       (expand-file-name (file-name-as-directory localdir))
+-    (concat doom-emacs-dir ".local/"))
++    (concat doom-emacs-dir "@local@/"))
    "Root directory for local storage.
  
  Use this as a storage location for this system's installation of Doom Emacs.
-@@ -83,13 +83,13 @@ Use this as a storage location for this system's installation of Doom Emacs.
+@@ -75,13 +75,13 @@ Use this as a storage location for this system's installation of Doom Emacs.
  These files should not be shared across systems. By default, it is used by
  `doom-etc-dir' and `doom-cache-dir'. Must end with a slash.")
  
@@ -27,13 +27,13 @@ index a5f7664db..894c1d641 100644
    "Directory for volatile local storage.
  
  Use this for files that change often, like cache files. Must end with a slash.")
-@@ -175,7 +175,8 @@ users).")
- ;; Don't store eln files in ~/.emacs.d/eln-cache (they are likely to be purged
- ;; when upgrading Doom).
- (when (boundp 'native-comp-eln-load-path)
--  (add-to-list 'native-comp-eln-load-path (concat doom-cache-dir "eln/")))
-+  (add-to-list 'native-comp-eln-load-path (concat doom-cache-dir "eln/"))
-+  (add-to-list 'native-comp-eln-load-path (concat doom-local-dir "cache/eln/")))
+@@ -181,7 +181,8 @@ users).")
+   ;; Don't store eln files in ~/.emacs.d/eln-cache (they are likely to be purged
+   ;; when upgrading Doom).
+   (when (boundp 'native-comp-eln-load-path)
+-    (add-to-list 'native-comp-eln-load-path (concat doom-cache-dir "eln/"))))
++    (add-to-list 'native-comp-eln-load-path (concat doom-cache-dir "eln/"))
++    (add-to-list 'native-comp-eln-load-path (concat doom-local-dir "cache/eln/"))))
  
  (with-eval-after-load 'comp
    ;; HACK Disable native-compilation for some troublesome packages


### PR DESCRIPTION
Rebase `nix-integration.patch` on top of doom-emacs/0869d2848.

This will become relevant in the future when updating doom-emacs to a later version. I leave that decision up to you but make the PR to help you whenever you do decide to bump the version of doom-emacs.

Tested and working as of 0869d2848.