### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,6 @@ let
   };
 in {
   home.packages = [ doom-emacs ];
-  home.file.".emacs.d/init.el".text = ''
-      (load "default.el")
-  '';
 }
 ```
 


### PR DESCRIPTION
Remove redundant loading of `init.el` in home-manager installation instructions.
The home-manager already does this, which causes `init.el` to be loaded twice if the user also adds this snippet to their config.