### PR TITLE
Assert that doomPrivateDir is a path

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -65,6 +65,8 @@
 , writeShellScriptBin
 , writeTextDir }:
 
+assert (lib.assertMsg (builtins.isPath doomPrivateDir) "doomPrivateDir must be a path");
+
 let
   flake = import ./flake-compat-helper.nix { src=./.; };
   lock = p: if dependencyOverrides ? ${p}


### PR DESCRIPTION
A user in https://github.com/vlaci/nix-doom-emacs/issues/379 was trying to provide the private dir as a stringified path, when it should have been an actual path. This adds an error message that will hopefully make it more obvious to future users.